### PR TITLE
Update FileRoller.cs

### DIFF
--- a/src/Serilog.Sinks.LiteDB/Sinks/LiteDB/FileRoller.cs
+++ b/src/Serilog.Sinks.LiteDB/Sinks/LiteDB/FileRoller.cs
@@ -19,6 +19,11 @@ namespace Serilog.Sinks.LiteDB
         /// <returns></returns>
         public static string GetFilename(string connectionString, RollingPeriod period, DateTime date)
         {
+            if (period == RollingPeriod.Never)
+            {
+                return connectionString;
+            }
+            
             var c = ConnectionStringParser.Parse(connectionString);
             var fullpath = c["filename"];
 
@@ -30,8 +35,6 @@ namespace Serilog.Sinks.LiteDB
 
             switch (period)
             {
-                case RollingPeriod.Never:
-                    return fullpath;
                 case RollingPeriod.HalfHour:
                 case RollingPeriod.Quarterly:
                     var itv = period == RollingPeriod.Quarterly ? 15 : 30;


### PR DESCRIPTION
See #11  

Ignore parsing the connection string when RollingPeriod.Never.
This allows the usage of custom ConnectionStrings with Password or Shared=true.

Change-Id: I88d1e7ebd73086fb00f4aefb4b77d8613e7b81d9